### PR TITLE
Added constructor overloads to allow supply of a Uri or DnsEndPoint

### DIFF
--- a/src/EventStore.ClientAPI.NetCore/Projections/QueryManager.cs
+++ b/src/EventStore.ClientAPI.NetCore/Projections/QueryManager.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Net;
-using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Common.Utils.Threading;
 using EventStore.ClientAPI.SystemData;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace EventStore.ClientAPI.Projections
 {
@@ -21,13 +21,38 @@ namespace EventStore.ClientAPI.Projections
         /// Creates a new instance of <see cref="QueryManager"/>.
         /// </summary>
         /// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
-        /// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
+        /// <param name="ipHttpEndPoint">HTTP IP endpoint of an Event Store server.</param>
         /// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
         /// <param name="queryTimeout">Timeout of query execution</param>
-        public QueryManager(ILogger log, IPEndPoint httpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout)
+        public QueryManager(ILogger log, IPEndPoint ipHttpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout)
         {
             _queryTimeout = queryTimeout;
-            _projectionsManager = new ProjectionsManager(log, httpEndPoint, projectionOperationTimeout);
+            _projectionsManager = new ProjectionsManager(log, ipHttpEndPoint, projectionOperationTimeout);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="QueryManager"/>.
+        /// </summary>
+        /// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
+        /// <param name="dnsHttpEndPoint">HTTP DNS endpoint of an Event Store server.</param>
+        /// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
+        /// <param name="queryTimeout">Timeout of query execution</param>
+        public QueryManager(ILogger log, DnsEndPoint dnsHttpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout)
+        {
+            _queryTimeout = queryTimeout;
+            _projectionsManager = new ProjectionsManager(log, dnsHttpEndPoint, projectionOperationTimeout);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="T:EventStore.ClientAPI.Projections.QueryManager" />.
+        /// </summary>
+        /// <param name="log">An instance of <see cref="T:EventStore.ClientAPI.ILogger" /> to use for logging.</param>
+        /// <param name="uri">HTTP URI endpoint of an Event Store server.</param>
+        /// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
+        /// <param name="queryTimeout">Timeout of query execution</param>
+        public QueryManager(ILogger log, Uri uri, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout)
+            : this(log, new DnsEndPoint(uri.Host, uri.Port), projectionOperationTimeout, queryTimeout)
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
I've started using QueryManager and was flummoxed to discover that I couldn't create an instance passing in a Uri as I was doing elsewhere with the client Api (e.g. EventStoreConnection.Create) we have the Uri to the event store server in our config settings already, it would be unpleasant to have to store both the Uri and IP address separately.