### PR TITLE
Add setting to override http client & setting to enable tls gossip communication

### DIFF
--- a/src/EventStore.ClientAPI.NetCore/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI.NetCore/ConnectionSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
 
@@ -18,6 +19,11 @@ namespace EventStore.ClientAPI
         /// The default <see cref="ConnectionSettings"></see>.
         /// </summary>
         public static ConnectionSettings Default { get { return DefaultSettings.Value; } }
+
+        /// <summary>
+        /// Allows overriding the HTTPClients <see cref="HttpClientHandler"/>
+        /// </summary>
+        public HttpClientHandler CustomHttpClientHandler { get; set; }
 
         /// <summary>
         /// Creates a new set of <see cref="ConnectionSettings"/>.
@@ -122,7 +128,7 @@ namespace EventStore.ClientAPI
         public readonly TimeSpan GossipTimeout;
 
         /// <summary>
-        /// Whether to randomly choose a node that's alive from the known nodes. 
+        /// Whether to randomly choose a node that's alive from the known nodes.
         /// </summary>
         public readonly bool PreferRandomNode;
 
@@ -151,10 +157,11 @@ namespace EventStore.ClientAPI
                                     TimeSpan clientConnectionTimeout,
                                     string clusterDns,
                                     GossipSeed[] gossipSeeds,
-                                    int maxDiscoverAttempts, 
-                                    int externalGossipPort, 
+                                    int maxDiscoverAttempts,
+                                    int externalGossipPort,
                                     TimeSpan gossipTimeout,
-                                    bool preferRandomNode)
+                                    bool preferRandomNode,
+                                    HttpClientHandler connectionSettingsCustomHttpClientHandler)
         {
             Ensure.NotNull(log, "log");
             Ensure.Positive(maxQueueSize, "maxQueueSize");
@@ -190,6 +197,7 @@ namespace EventStore.ClientAPI
             ExternalGossipPort = externalGossipPort;
             GossipTimeout = gossipTimeout;
             PreferRandomNode = preferRandomNode;
+            CustomHttpClientHandler = connectionSettingsCustomHttpClientHandler;
         }
     }
 }

--- a/src/EventStore.ClientAPI.NetCore/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI.NetCore/ConnectionSettingsBuilder.cs
@@ -400,36 +400,12 @@ namespace EventStore.ClientAPI
         /// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
         ///  <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
         ///  <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-        public ConnectionSettingsBuilder SetGossipSeedEndPoints(bool tlsTerminatedEndpoints, params IPEndPoint[] gossipSeeds)
+        public ConnectionSettingsBuilder SetGossipSeedEndPoints(bool tlsTerminatedEndpoints = false, params IPEndPoint[] gossipSeeds)
         {
             if (gossipSeeds == null || gossipSeeds.Length == 0)
                 throw new ArgumentException("Empty FakeDnsEntries collection.");
 
             _gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x, endpointIsTlsTerminated:tlsTerminatedEndpoints)).ToArray();
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets gossip seed endpoints for the client.
-        ///
-        /// <note>
-        /// This should be the external HTTP endpoint of the server, as it is required
-        /// for the client to exchange gossip with the server. The standard port is 2113.
-        /// </note>
-        ///
-        /// If the server requires a specific Host header to be sent as part of the gossip
-        /// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
-        /// </summary>
-        /// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        /// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-        public ConnectionSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds)
-        {
-            if (gossipSeeds == null || gossipSeeds.Length == 0)
-                throw new ArgumentException("Empty FakeDnsEntries collection.");
-
-            _gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x)).ToArray();
 
             return this;
         }

--- a/src/EventStore.ClientAPI.NetCore/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI.NetCore/EventStoreConnection.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Linq;
-using System.Net.Sockets;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Internal;
 using System;
@@ -101,7 +100,8 @@ namespace EventStore.ClientAPI
                         connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns,
                         connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
                         connectionSettings.ExternalGossipPort, connectionSettings.GossipTimeout,
-                        connectionSettings.PreferRandomNode);
+                        connectionSettings.PreferRandomNode,
+                        connectionSettings.CustomHttpClientHandler);
                 }
                 if (scheme == "discover")
                 {
@@ -116,7 +116,8 @@ namespace EventStore.ClientAPI
                         clusterSettings.ExternalGossipPort,
                         clusterSettings.GossipSeeds,
                         clusterSettings.GossipTimeout,
-                        clusterSettings.PreferRandomNode);
+                        clusterSettings.PreferRandomNode,
+                        connectionSettings.CustomHttpClientHandler);
 
                     return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
                         connectionName);
@@ -144,7 +145,8 @@ namespace EventStore.ClientAPI
                     clusterSettings.ExternalGossipPort,
                     clusterSettings.GossipSeeds,
                     clusterSettings.GossipTimeout,
-                    clusterSettings.PreferRandomNode);
+                    clusterSettings.PreferRandomNode,
+                    connectionSettings.CustomHttpClientHandler);
 
                 return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
                     connectionName);
@@ -192,7 +194,7 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Creates a new <see cref="IEventStoreConnection"/> to EventStore cluster 
+        /// Creates a new <see cref="IEventStoreConnection"/> to EventStore cluster
         /// using specific <see cref="ConnectionSettings"/> and <see cref="ClusterSettings"/>
         /// </summary>
         /// <param name="connectionSettings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
@@ -210,7 +212,8 @@ namespace EventStore.ClientAPI
                                                                       clusterSettings.ExternalGossipPort,
                                                                       clusterSettings.GossipSeeds,
                                                                       clusterSettings.GossipTimeout,
-                                                                      clusterSettings.PreferRandomNode);
+                                                                      clusterSettings.PreferRandomNode,
+                                                                      connectionSettings.CustomHttpClientHandler);
 
             return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer, connectionName);
         }

--- a/src/EventStore.ClientAPI.NetCore/GossipSeed.cs
+++ b/src/EventStore.ClientAPI.NetCore/GossipSeed.cs
@@ -9,7 +9,7 @@ namespace EventStore.ClientAPI
     {
         /// <summary>
         /// The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed.
-        /// 
+        ///
         /// The HTTP endpoint is used rather than the TCP endpoint because it is required
         /// for the client to exchange gossip with the server. The standard port which should be
         /// used here is 2113.
@@ -21,14 +21,21 @@ namespace EventStore.ClientAPI
         public readonly string HostHeader;
 
         /// <summary>
+        /// If Gossip should be requested
+        /// </summary>
+        public readonly bool EndpointIsTlsTerminated;
+
+        /// <summary>
         /// Creates a new <see cref="GossipSeed" />.
         /// </summary>
         /// <param name="endPoint">The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed. The standard port is 2113.</param>
         /// <param name="hostHeader">The host header to be sent when requesting gossip. Defaults to String.Empty</param>
-        public GossipSeed(IPEndPoint endPoint, string hostHeader = "")
+        /// <param name="endpointIsTlsTerminated">The endpoint should be accessed over https; Defaults to false</param>
+        public GossipSeed(IPEndPoint endPoint, string hostHeader = "", bool endpointIsTlsTerminated = false)
         {
             EndPoint = endPoint;
             HostHeader = hostHeader;
+            EndpointIsTlsTerminated = endpointIsTlsTerminated;
         }
     }
 }

--- a/src/EventStore.ClientAPI.NetCore/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI.NetCore/GossipSeedClusterSettingsBuilder.cs
@@ -14,13 +14,14 @@ namespace EventStore.ClientAPI
         private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
         private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
         private bool _preferRandomNode = false;
+        private bool _useTlsTerminatedSSL = false;
 
         /// <summary>
         /// Sets gossip seed endpoints for the client.
         /// TODO: This was a note.
         /// This should be the external HTTP endpoint of the server, as it is required
         /// for the client to exchange gossip with the server. The standard port is 2113.
-        /// 
+        ///
         /// If the server requires a specific Host header to be sent as part of the gossip
         /// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
         /// </summary>
@@ -77,7 +78,17 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Whether to randomly choose a node that's alive from the known nodes. 
+        /// Whether to randomly choose a node that's alive from the known nodes.
+        /// </summary>
+        /// <returns>A <see cref="GossipSeedClusterSettingsBuilder"/> for further configuration.</returns>
+        public GossipSeedClusterSettingsBuilder GossipEndpointIsTlsTerminated()
+        {
+            _useTlsTerminatedSSL = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Whether to randomly choose a node that's alive from the known nodes.
         /// </summary>
         /// <returns>A <see cref="GossipSeedClusterSettingsBuilder"/> for further configuration.</returns>
         public GossipSeedClusterSettingsBuilder PreferRandomNode()
@@ -85,6 +96,7 @@ namespace EventStore.ClientAPI
             _preferRandomNode = true;
             return this;
         }
+
 
         /// <summary>
         /// Builds a <see cref="ClusterSettings"/> object from a <see cref="GossipSeedClusterSettingsBuilder"/>.

--- a/src/EventStore.ClientAPI.NetCore/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI.NetCore/GossipSeedClusterSettingsBuilder.cs
@@ -14,7 +14,6 @@ namespace EventStore.ClientAPI
         private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
         private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
         private bool _preferRandomNode = false;
-        private bool _useTlsTerminatedSSL = false;
 
         /// <summary>
         /// Sets gossip seed endpoints for the client.
@@ -25,30 +24,17 @@ namespace EventStore.ClientAPI
         /// If the server requires a specific Host header to be sent as part of the gossip
         /// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
         /// </summary>
-        /// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        /// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-        public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds)
-        {
-            if (gossipSeeds == null || gossipSeeds.Length == 0)
-                throw new ArgumentException("Empty FakeDnsEntries collection.");
-
-            _gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x)).ToArray();
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets gossip seed endpoints for the client.
-        /// </summary>
+        /// <param name="tlsTerminatedEndpoints">Specifies that eventstore should use https when connecting to gossip</param>
         /// <param name="gossipSeeds"><see cref="GossipSeed"/>s representing the endpoints of nodes from which to seed gossip.</param>
         /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
         /// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-        public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(params GossipSeed[] gossipSeeds)
+        public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(bool tlsTerminatedEndpoints = false, params IPEndPoint[] gossipSeeds)
         {
             if (gossipSeeds == null || gossipSeeds.Length == 0)
                 throw new ArgumentException("Empty FakeDnsEntries collection.");
-            _gossipSeeds = gossipSeeds;
+
+            _gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x, endpointIsTlsTerminated: tlsTerminatedEndpoints)).ToArray();
+
             return this;
         }
 
@@ -74,16 +60,6 @@ namespace EventStore.ClientAPI
         public GossipSeedClusterSettingsBuilder SetGossipTimeout(TimeSpan timeout)
         {
             _gossipTimeout = timeout;
-            return this;
-        }
-
-        /// <summary>
-        /// Whether to randomly choose a node that's alive from the known nodes.
-        /// </summary>
-        /// <returns>A <see cref="GossipSeedClusterSettingsBuilder"/> for further configuration.</returns>
-        public GossipSeedClusterSettingsBuilder GossipEndpointIsTlsTerminated()
-        {
-            _useTlsTerminatedSSL = true;
             return this;
         }
 

--- a/src/EventStore.ClientAPI.NetCore/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI.NetCore/Projections/ProjectionsClient.cs
@@ -15,10 +15,10 @@ namespace EventStore.ClientAPI.Projections
         private readonly HttpAsyncClient _client;
         private readonly TimeSpan _operationTimeout;
 
-        public ProjectionsClient(ILogger log, TimeSpan operationTimeout)
+        public ProjectionsClient(ILogger log, TimeSpan operationTimeout, System.Net.Http.HttpClientHandler clienthandler)
         {
             _operationTimeout = operationTimeout;
-            _client = new HttpAsyncClient(_operationTimeout);
+            _client = new HttpAsyncClient(_operationTimeout, clienthandler);
         }
 
         public Task Enable(EndPoint endPoint, string name, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA)

--- a/src/EventStore.ClientAPI.NetCore/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI.NetCore/Projections/ProjectionsManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
@@ -24,19 +25,22 @@ namespace EventStore.ClientAPI.Projections
         /// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
         /// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
         /// <param name="operationTimeout"></param>
+        /// <param name="clienthandler"></param>
         /// <param name="httpSchema">HTTP endpoint schema http|https.</param>
-        public ProjectionsManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout, string httpSchema = EndpointExtensions.HTTP_SCHEMA)
+        /// <param name="clienthandler">Overideable HTTP Client Handler</param>
+        public ProjectionsManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout,
+            HttpClientHandler clienthandler = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA)
         {
             Ensure.NotNull(log, "log");
             Ensure.NotNull(httpEndPoint, "httpEndPoint");
 
-            _client = new ProjectionsClient(log, operationTimeout);
+            _client = new ProjectionsClient(log, operationTimeout, clienthandler);
             _httpEndPoint = httpEndPoint;
             _httpSchema = httpSchema;
         }
 
         /// <summary>
-        /// Asynchronously enables a projection 
+        /// Asynchronously enables a projection
         /// </summary>
         /// <param name="name">The name of the projection.</param>
         /// <param name="userCredentials">Credentials for a user with permission to enable a projection</param>
@@ -302,7 +306,7 @@ namespace EventStore.ClientAPI.Projections
         }
 
         /// <summary>
-        /// Asynchronously deletes a projection 
+        /// Asynchronously deletes a projection
         /// </summary>
         /// <param name="name">The name of the projection.</param>
         /// <param name="userCredentials">Credentials for a user with permission to delete a projection</param>
@@ -313,7 +317,7 @@ namespace EventStore.ClientAPI.Projections
         }
 
         /// <summary>
-        /// Asynchronously deletes a projection 
+        /// Asynchronously deletes a projection
         /// </summary>
         /// <param name="name">The name of the projection.</param>
         /// <param name="deleteEmittedStreams">Whether to delete the streams that were emitted by this projection.</param>

--- a/src/EventStore.ClientAPI.NetCore/Projections/QueryManager.cs
+++ b/src/EventStore.ClientAPI.NetCore/Projections/QueryManager.cs
@@ -4,12 +4,13 @@ using EventStore.ClientAPI.SystemData;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace EventStore.ClientAPI.Projections
 {
     /// <summary>
-    /// API for executinmg queries in the Event Store through C# code. Communicates
+    /// API for executing queries in the Event Store through C# code. Communicates
     /// with the Event Store over the RESTful API.
     /// </summary>
     public class QueryManager
@@ -24,10 +25,11 @@ namespace EventStore.ClientAPI.Projections
         /// <param name="ipHttpEndPoint">HTTP IP endpoint of an Event Store server.</param>
         /// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
         /// <param name="queryTimeout">Timeout of query execution</param>
-        public QueryManager(ILogger log, IPEndPoint ipHttpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout)
+        /// <param name="clienthandler">Overideable HTTP Client Handler</param>
+        public QueryManager(ILogger log, IPEndPoint ipHttpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout, HttpClientHandler clienthandler = null)
         {
             _queryTimeout = queryTimeout;
-            _projectionsManager = new ProjectionsManager(log, ipHttpEndPoint, projectionOperationTimeout);
+            _projectionsManager = new ProjectionsManager(log, ipHttpEndPoint, projectionOperationTimeout, clienthandler);
         }
 
         /// <summary>
@@ -37,10 +39,11 @@ namespace EventStore.ClientAPI.Projections
         /// <param name="dnsHttpEndPoint">HTTP DNS endpoint of an Event Store server.</param>
         /// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
         /// <param name="queryTimeout">Timeout of query execution</param>
-        public QueryManager(ILogger log, DnsEndPoint dnsHttpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout)
+        /// <param name="clienthandler">Overideable HTTP Client Handler</param>
+        public QueryManager(ILogger log, DnsEndPoint dnsHttpEndPoint, TimeSpan projectionOperationTimeout, TimeSpan queryTimeout, HttpClientHandler clienthandler = null)
         {
             _queryTimeout = queryTimeout;
-            _projectionsManager = new ProjectionsManager(log, dnsHttpEndPoint, projectionOperationTimeout);
+            _projectionsManager = new ProjectionsManager(log, dnsHttpEndPoint, projectionOperationTimeout, clienthandler);
         }
 
         /// <summary>

--- a/src/EventStore.ClientAPI.NetCore/Transport.Http/HttpAsyncClient.cs
+++ b/src/EventStore.ClientAPI.NetCore/Transport.Http/HttpAsyncClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Net;
 using System.Text;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
@@ -14,10 +13,11 @@ namespace EventStore.ClientAPI.Transport.Http
     {
         private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         private HttpClient _client;
-        
-        public HttpAsyncClient(TimeSpan timeout) 
+
+        public HttpAsyncClient(TimeSpan timeout, HttpClientHandler clienthandler = null)
         {
-            _client = new HttpClient();
+
+            _client = clienthandler == null ? new HttpClient() : new HttpClient(clienthandler);
             _client.Timeout = timeout;
         }
 
@@ -133,10 +133,10 @@ namespace EventStore.ClientAPI.Transport.Http
             };
         }
 
-        private Action<Task<string>> ResponseRead(ClientOperationState state) 
+        private Action<Task<string>> ResponseRead(ClientOperationState state)
         {
             return task => {
-                try 
+                try
                 {
                     state.Response.Body = task.Result;
                     state.Dispose();

--- a/src/EventStore.ClientAPI.NetCore/UserManagement/UsersClient.cs
+++ b/src/EventStore.ClientAPI.NetCore/UserManagement/UsersClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using HttpStatusCode = EventStore.ClientAPI.Transport.Http.HttpStatusCode;
@@ -15,12 +16,14 @@ namespace EventStore.ClientAPI.UserManagement
     {
         private readonly HttpAsyncClient _client;
 
+        private readonly ILogger _log;
         private readonly TimeSpan _operationTimeout;
 
-        public UsersClient(ILogger log, TimeSpan operationTimeout)
+        public UsersClient(ILogger log, TimeSpan operationTimeout, HttpClientHandler handler)
         {
+            _log = log;
             _operationTimeout = operationTimeout;
-            _client = new HttpAsyncClient(_operationTimeout);
+            _client = new HttpAsyncClient(_operationTimeout, handler);
         }
 
         public Task Enable(EndPoint endPoint, string login, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA)

--- a/src/EventStore.ClientAPI.NetCore/UserManagement/UsersManager.cs
+++ b/src/EventStore.ClientAPI.NetCore/UserManagement/UsersManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
@@ -25,14 +26,17 @@ namespace EventStore.ClientAPI.UserManagement
         /// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
         /// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
         /// <param name="operationTimeout"></param>
-        public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout, string httpSchema = EndpointExtensions.HTTP_SCHEMA)
+        /// <param name="useSslConnection"></param>
+        /// <param name="handler">override httpclient handler</param>
+        public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout,
+            bool useSslConnection = false, HttpClientHandler handler = null)
         {
             Ensure.NotNull(log, "log");
             Ensure.NotNull(httpEndPoint, "httpEndPoint");
 
-            _client = new UsersClient(log, operationTimeout);
+            _client = new UsersClient(log, operationTimeout, handler);
             _httpEndPoint = httpEndPoint;
-            _httpSchema = httpSchema;
+            _httpSchema = useSslConnection ? EndpointExtensions.HTTPS_SCHEMA : EndpointExtensions.HTTP_SCHEMA;
         }
 
         /// <summary>
@@ -44,7 +48,7 @@ namespace EventStore.ClientAPI.UserManagement
         public Task EnableAsync(string login, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(login, "login");
-            return _client.Enable(_httpEndPoint, login, userCredentials);
+            return _client.Enable(_httpEndPoint, login, userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -56,7 +60,7 @@ namespace EventStore.ClientAPI.UserManagement
         public Task DisableAsync(string login, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(login, "login");
-            return _client.Disable(_httpEndPoint, login, userCredentials);
+            return _client.Disable(_httpEndPoint, login, userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -68,7 +72,7 @@ namespace EventStore.ClientAPI.UserManagement
         public Task DeleteUserAsync(string login, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(login, "login");
-            return _client.Delete(_httpEndPoint, login, userCredentials);
+            return _client.Delete(_httpEndPoint, login, userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -76,9 +80,9 @@ namespace EventStore.ClientAPI.UserManagement
         /// </summary>
         /// <param name="userCredentials">Credentials for the operation.</param>
         /// <returns>String of JSON containing user full names and logins.</returns>
-        public Task<List<UserDetails>> ListAllAsync(UserCredentials userCredentials = null) 
+        public Task<List<UserDetails>> ListAllAsync(UserCredentials userCredentials = null)
         {
-            return _client.ListAll(_httpEndPoint, userCredentials);
+            return _client.ListAll(_httpEndPoint, userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -86,9 +90,9 @@ namespace EventStore.ClientAPI.UserManagement
         /// </summary>
         /// <param name="userCredentials">Credentials for the operation.</param>
         /// <returns>A <see cref="UserDetails"/> object for the currently logged in user</returns>
-        public Task<UserDetails> GetCurrentUserAsync(UserCredentials userCredentials) 
+        public Task<UserDetails> GetCurrentUserAsync(UserCredentials userCredentials)
         {
-            return _client.GetCurrentUser(_httpEndPoint, userCredentials);
+            return _client.GetCurrentUser(_httpEndPoint, userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -97,10 +101,10 @@ namespace EventStore.ClientAPI.UserManagement
         /// <param name="login">the login for the user who's details should be retrieved.</param>
         /// <param name="userCredentials">Credentials for the operation.</param>
         /// <returns>A <see cref="UserDetails"/> object for the user</returns>
-        public Task<UserDetails> GetUserAsync(string login, UserCredentials userCredentials) 
+        public Task<UserDetails> GetUserAsync(string login, UserCredentials userCredentials)
         {
             Ensure.NotNullOrEmpty(login, "login");
-            return _client.GetUser(_httpEndPoint, login, userCredentials);
+            return _client.GetUser(_httpEndPoint, login, userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -119,8 +123,7 @@ namespace EventStore.ClientAPI.UserManagement
             Ensure.NotNullOrEmpty(fullName, "fullName");
             Ensure.NotNull(groups, "groups");
             Ensure.NotNullOrEmpty(password, "password");
-            return _client.CreateUser(_httpEndPoint, new UserCreationInformation(login, fullName, groups, password),
-                userCredentials);
+            return _client.CreateUser(_httpEndPoint, new UserCreationInformation(login, fullName, groups, password), userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -136,7 +139,7 @@ namespace EventStore.ClientAPI.UserManagement
             Ensure.NotNullOrEmpty(login, "login");
             Ensure.NotNullOrEmpty(fullName, "fullName");
             Ensure.NotNull(groups, "groups");
-            return _client.UpdateUser(_httpEndPoint, login, new UserUpdateInformation(fullName, groups), userCredentials);
+            return _client.UpdateUser(_httpEndPoint, login, new UserUpdateInformation(fullName, groups), userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -153,8 +156,7 @@ namespace EventStore.ClientAPI.UserManagement
             Ensure.NotNullOrEmpty(login, "login");
             Ensure.NotNullOrEmpty(oldPassword, "oldPassword");
             Ensure.NotNullOrEmpty(newPassword, "newPassword");
-            return _client.ChangePassword(_httpEndPoint, login, new ChangePasswordDetails(oldPassword, newPassword),
-                userCredentials);
+            return _client.ChangePassword(_httpEndPoint, login, new ChangePasswordDetails(oldPassword, newPassword), userCredentials, _httpSchema);
         }
 
         /// <summary>
@@ -168,7 +170,7 @@ namespace EventStore.ClientAPI.UserManagement
         {
             Ensure.NotNullOrEmpty(login, "login");
             Ensure.NotNullOrEmpty(newPassword, "newPassword");
-            return _client.ResetPassword(_httpEndPoint, login, new ResetPasswordDetails(newPassword), userCredentials);
+            return _client.ResetPassword(_httpEndPoint, login, new ResetPasswordDetails(newPassword), userCredentials, _httpSchema);
         }
     }
 }

--- a/src/EventStore.ClientAPI.NetCore/UserManagement/UsersManager.cs
+++ b/src/EventStore.ClientAPI.NetCore/UserManagement/UsersManager.cs
@@ -26,17 +26,17 @@ namespace EventStore.ClientAPI.UserManagement
         /// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
         /// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
         /// <param name="operationTimeout"></param>
-        /// <param name="useSslConnection"></param>
+        /// <param name="tlsTerminatedEndpoint"></param>
         /// <param name="handler">override httpclient handler</param>
         public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout,
-            bool useSslConnection = false, HttpClientHandler handler = null)
+            bool tlsTerminatedEndpoint = false, HttpClientHandler handler = null)
         {
             Ensure.NotNull(log, "log");
             Ensure.NotNull(httpEndPoint, "httpEndPoint");
 
             _client = new UsersClient(log, operationTimeout, handler);
             _httpEndPoint = httpEndPoint;
-            _httpSchema = useSslConnection ? EndpointExtensions.HTTPS_SCHEMA : EndpointExtensions.HTTP_SCHEMA;
+            _httpSchema = tlsTerminatedEndpoint ? EndpointExtensions.HTTPS_SCHEMA : EndpointExtensions.HTTP_SCHEMA;
         }
 
         /// <summary>


### PR DESCRIPTION
* Adds the ability to feed a custom http handler to the HttpClient ClusterSettings.Create().GossipEndpointIsTlsTerminated()

* Adds the ability to call Gossip over HTTPs `ConnectionSettings.Create().UseCustomHttpClientHandler(handler)`

Refs Issue #28 

I've tried to make it so there are no accidental knock-on effects by defaulting to normal behaviour.
Let me know if you've any issues around naming; I was paranoid that naming the gossip-tls option non-specific to tls termination might cause confusion around support for it ala https://github.com/EventStore/EventStore/issues/1017

